### PR TITLE
feat: add node-like fs behavior to custom root directories with files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-const queueMicrotask = require('queue-microtask')
-
+/* eslint-env browser */
 class WebFsChunkStore {
   constructor (chunkLength, opts = {}) {
     this.chunkLength = Number(chunkLength)
@@ -9,19 +8,78 @@ class WebFsChunkStore {
     }
 
     this.closed = false
-    this.length = Number(opts.length) || Infinity
-
-    if (this.length !== Infinity) {
-      this.lastChunkLength = this.length % this.chunkLength || this.chunkLength
-      this.lastChunkIndex = Math.ceil(this.length / this.chunkLength) - 1
-    }
 
     this.name = opts.name || 'default'
 
     this.rootDirPromise = opts.rootDir || navigator.storage.getDirectory()
     this.storageDirPromise = this._getStorageDirectoryHandle()
+    this.chunksDirPromise = ((opts.files && opts.rootDir) && this._getChunksDirHandle()) || this.storageDirPromise
 
-    this.chunks = []
+    this.chunks = [] // individual chunks, required for reads :/
+    this.chunkMap = [] // full files
+    this.directoryMap = {}
+
+    if (opts.files && opts.rootDir) {
+      this.files = opts.files.slice(0).map((file, i, files) => {
+        if (file.path == null) throw new Error('File is missing `path` property')
+        if (file.length == null) throw new Error('File is missing `length` property')
+        if (file.offset == null) {
+          if (i === 0) {
+            file.offset = 0
+          } else {
+            const prevFile = files[i - 1]
+            file.offset = prevFile.offset + prevFile.length
+          }
+        }
+
+        // file handles
+        if (file.handle == null) {
+          file.handle = this._createFileHandle({ path: file.path })
+        }
+
+        // file chunkMap
+        const fileStart = file.offset
+        const fileEnd = file.offset + file.length
+
+        const firstChunk = Math.floor(fileStart / this.chunkLength)
+        const lastChunk = Math.floor((fileEnd - 1) / this.chunkLength)
+
+        for (let p = firstChunk; p <= lastChunk; ++p) {
+          const chunkStart = p * this.chunkLength
+          const chunkEnd = chunkStart + this.chunkLength
+
+          const from = (fileStart < chunkStart) ? 0 : fileStart - chunkStart
+          const to = (fileEnd > chunkEnd) ? this.chunkLength : fileEnd - chunkStart
+          const offset = (fileStart > chunkStart) ? 0 : chunkStart - fileStart
+
+          if (!this.chunkMap[p]) this.chunkMap[p] = []
+
+          this.chunkMap[p].push({ from, to, offset, file })
+        }
+
+        return file
+      })
+
+      // close streams is page is frozen/unloaded, they will re-open if the user returns via BFC
+      window.addEventListener('pagehide', this.cleanup)
+
+      this.length = this.files.reduce((sum, file) => sum + file.length, 0)
+      if (opts.length != null && opts.length !== this.length) {
+        throw new Error('total `files` length is not equal to explicit `length` option')
+      }
+    } else {
+      this.length = Number(opts.length) || Infinity
+    }
+
+    if (this.length !== Infinity) {
+      this.lastChunkLength = this.length % this.chunkLength || this.chunkLength
+      this.lastChunkIndex = Math.ceil(this.length / this.chunkLength) - 1
+    }
+  }
+
+  async _getChunksDirHandle () {
+    const storageDir = await this.storageDirPromise
+    return await storageDir.getDirectoryHandle('chunks', { create: true })
   }
 
   async _getStorageDirectoryHandle () {
@@ -34,14 +92,29 @@ class WebFsChunkStore {
 
     if (!chunk) {
       const fileName = index.toString()
-      const storageDir = await this.storageDirPromise
+      const storageDir = await this.chunksDirPromise
 
-      chunk = this.chunks[index] = {
-        fileHandlePromise: storageDir.getFileHandle(fileName, { create: true })
-      }
+      chunk = this.chunks[index] = { fileHandlePromise: storageDir.getFileHandle(fileName, { create: true }) }
     }
 
     return chunk
+  }
+
+  async _createFileHandle (opts) {
+    const fileName = opts.path.slice(opts.path.lastIndexOf('/') + 1)
+    return (await this._getDirectoryHandle(opts)).getFileHandle(fileName, { create: true })
+  }
+
+  // recursive, equiv of cd and mkdirp
+  async _getDirectoryHandle (opts) {
+    const lastIndex = opts.path.lastIndexOf('/')
+    if (lastIndex === -1 || lastIndex === 0) return this.storageDirPromise
+    const path = opts.path = opts.path.slice(0, lastIndex)
+    if (!this.directoryMap[path]) {
+      const parent = this._getDirectoryHandle(opts)
+      this.directoryMap[path] = (await parent).getDirectoryHandle(path.slice(path.lastIndexOf('/') + 1), { create: true })
+    }
+    return this.directoryMap[path]
   }
 
   put (index, buf, cb = () => {}) {
@@ -78,8 +151,33 @@ class WebFsChunkStore {
         return
       }
 
-      cb(null)
+      if (!this.files) cb(null)
     })()
+
+    if (this.files) {
+      const targets = this.chunkMap[index]
+      if (!targets) {
+        queueMicrotask(() => cb(new Error('No files matching the request range')))
+      }
+      const promises = targets.map(target => {
+        return (async () => {
+          try {
+            const { file } = target
+            if (!file.stream) {
+              file.stream = (await file.handle).createWritable({
+                keepExistingData: true
+              })
+            }
+            const stream = await file.stream
+            await stream.write({ type: 'write', position: target.offset, data: buf.slice(target.from, target.to) })
+            return null
+          } catch (err) {
+            return cb(err)
+          }
+        })()
+      })
+      Promise.all(promises).then(() => cb(null))
+    }
   }
 
   get (index, opts, cb = () => {}) {
@@ -96,33 +194,82 @@ class WebFsChunkStore {
 
     if (!opts) opts = {}
 
-    const offset = opts.offset || 0
-    const len = opts.length || chunkLength - offset
+    const rangeFrom = opts.offset || 0
+    const rangeTo = opts.length ? rangeFrom + opts.length : chunkLength
+    const len = opts.length || chunkLength - rangeFrom
 
-    ;(async () => {
-      let buf
-      try {
-        const chunk = await this._getChunk(index)
-        const fileHandle = await chunk.fileHandlePromise
-        let file = await fileHandle.getFile()
-        if (offset !== 0 || len !== chunkLength) {
-          file = file.slice(offset, len + offset)
+    if (!this.files || this.chunks[index]) {
+      ;(async () => {
+        let buf
+        try {
+          const chunk = await this._getChunk(index)
+          const fileHandle = await chunk.fileHandlePromise
+          let file = await fileHandle.getFile()
+          if (rangeFrom !== 0 || len !== chunkLength) {
+            file = file.slice(rangeFrom, len + rangeFrom)
+          }
+          buf = await file.arrayBuffer()
+        } catch (err) {
+          cb(err)
+          return
         }
-        buf = await file.arrayBuffer()
-      } catch (err) {
-        cb(err)
-        return
-      }
 
-      if (buf.byteLength === 0) {
-        const err = new Error(`Index ${index} does not exist`)
-        err.notFound = true
-        cb(err)
-        return
-      }
+        if (buf.byteLength === 0) {
+          const err = new Error(`Index ${index} does not exist`)
+          err.notFound = true
+          cb(err)
+          return
+        }
 
-      cb(null, Buffer.from(buf))
-    })()
+        cb(null, new Uint8Array(buf))
+      })()
+    } else {
+      let targets = this.chunkMap[index]
+      if (!targets) {
+        queueMicrotask(() => cb(new Error('No files matching the request range')))
+      }
+      if (opts) {
+        targets = targets.filter(target => {
+          return target.to > rangeFrom && target.from < rangeTo
+        })
+        if (targets.length === 0) {
+          queueMicrotask(() => cb(new Error('No files matching the request range')))
+        }
+      }
+      if (rangeFrom === rangeTo) return queueMicrotask(() => cb(new Uint8Array(0)))
+
+      const promises = targets.map(target => {
+        return (async () => {
+          let from = target.from
+          let to = target.to
+          let offset = target.offset
+
+          if (opts) {
+            if (to > rangeTo) to = rangeTo
+            if (from < rangeFrom) {
+              offset += (rangeFrom - from)
+              from = rangeFrom
+            }
+          }
+          try {
+            const handle = await target.file.handle
+            const file = (await handle.getFile()).slice(offset, offset + to - from)
+            return await file.arrayBuffer()
+          } catch (err) {
+            return err
+          }
+        })()
+      })
+      Promise.all(promises).then(values => {
+        if (values.length === 1) {
+          cb(null, new Uint8Array(values[0]))
+        } else {
+          new Blob(values).arrayBuffer().then(buf => {
+            cb(null, new Uint8Array(buf))
+          })
+        }
+      })
+    }
   }
 
   close (cb = () => {}) {
@@ -132,11 +279,28 @@ class WebFsChunkStore {
     }
 
     this.closed = true
-    this.chunks = []
+    this.chunkMap = []
+    this.directoryMap = {}
+
+    this.cleanup()
 
     queueMicrotask(() => {
       cb(null)
     })
+  }
+
+  async cleanup () {
+    if (this.files) {
+      for (const file of this.files) {
+        if (file.stream) {
+          await (await file.stream).close()
+          file.stream = null
+        }
+      }
+      const storageDir = await this.storageDirPromise
+      await storageDir.removeEntry('chunks', { recursive: true })
+    }
+    this.chunks = []
   }
 
   destroy (cb = () => {}) {

--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ class WebFsChunkStore {
           queueMicrotask(() => cb(new Error('No files matching the request range')))
         }
       }
-      if (rangeFrom === rangeTo) return queueMicrotask(() => cb(new Uint8Array(0)))
+      if (rangeFrom === rangeTo) return queueMicrotask(() => cb(null, new Uint8Array(0)))
 
       const promises = targets.map(target => {
         return (async () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

- copied the logic from fs-chunk-store, for storing/resolving which file a chunk belongs to
- created file handles for each file
- created a cd and mkdirp equivalent for fs-access-api
- created a secondary option to both gets and puts which only runs when a user has defined a custom rootDir and files
  - for puts: it additionally writes to the finished file, not only chunk files, which means it uses x2 as much storage space, but I couldn't find any other alternative which allowed for concurrent writes on the same file
  - for gets: it reads from the full file unless a put has happened to that file's index, this is because of how I handled puts, the write stream stays open until the store is closed, and the file's data won't be saved until the store is closed, that's why it reads from the individual chunk files in that case
- if a user has a custom rootDir and files, closing the store will delete the single chunk files, and save/build the full files, when the store is opened the next time, and the user wants to get a chunk index, he will first read from the full file as described above
- if a user has a custom rootDir and files, to prevent data loss when the browser freezes the tab, or the user closes it, added an event listener to close file streams when the page is hidden [not to be confused with visibility loss], additionally it removes the single chunk files, since the page will either be discarded, or un-frozen, in which case the file streams will be re-opened
additionally, this function could be triggered by webtorrent once a torrent has finished downloading to greatly reduce ram usage, and get rid of duplicate data on the drive

**Which issue (if any) does this pull request address?**
- user wanted to access the store again, but with different chunksizes
- user wanted a filesystem-like store with files and folders
- user wanted to externally modify files and store data